### PR TITLE
Added configuration flag to activate NADA congestion control at run time

### DIFF
--- a/media/webrtc/signaling/src/media-conduit/MediaConduitInterface.h
+++ b/media/webrtc/signaling/src/media-conduit/MediaConduitInterface.h
@@ -321,6 +321,22 @@ class WebRtcCallWrapper : public RefCounted<WebRtcCallWrapper> {
     auto audio_state = webrtc::AudioState::Create(audio_state_config);
     webrtc::Call::Config config(&mEventLog);
     config.audio_state = audio_state;
+    config.use_nada = false;
+
+    nsresult res;
+    nsCOMPtr<nsIPrefService> prefs =
+        do_GetService("@mozilla.org/preferences-service;1", &res);
+
+    if (NS_FAILED(res)) {
+      return;
+    }
+
+    nsCOMPtr<nsIPrefBranch> branch = do_QueryInterface(prefs);
+    if (!branch) {
+      return;
+    }
+
+    branch->GetBoolPref("media.navigator.video.use_nada", &config.use_nada);
     mCall.reset(webrtc::Call::Create(config));
   }
 

--- a/media/webrtc/trunk/webrtc/call/call.cc
+++ b/media/webrtc/trunk/webrtc/call/call.cc
@@ -414,7 +414,8 @@ std::string Call::Stats::ToString(int64_t time_ms) const {
 Call* Call::Create(const Call::Config& config) {
   return new internal::Call(config,
                             rtc::MakeUnique<RtpTransportControllerSend>(
-                                Clock::GetRealTimeClock(), config.event_log));
+                                Clock::GetRealTimeClock(), config.event_log,
+                                config.use_nada));
 }
 
 Call* Call::Create(

--- a/media/webrtc/trunk/webrtc/call/call.h
+++ b/media/webrtc/trunk/webrtc/call/call.h
@@ -113,6 +113,7 @@ class Call {
     // RtcEventLog to use for this call. Required.
     // Use webrtc::RtcEventLog::CreateNull() for a null implementation.
     RtcEventLog* event_log = nullptr;
+    bool use_nada;
   };
 
   struct Stats {

--- a/media/webrtc/trunk/webrtc/call/rtp_transport_controller_send.cc
+++ b/media/webrtc/trunk/webrtc/call/rtp_transport_controller_send.cc
@@ -14,9 +14,10 @@ namespace webrtc {
 
 RtpTransportControllerSend::RtpTransportControllerSend(
     Clock* clock,
-    webrtc::RtcEventLog* event_log)
+    webrtc::RtcEventLog* event_log,
+    bool use_nada)
     : pacer_(clock, &packet_router_, event_log),
-      send_side_cc_(clock, nullptr /* observer */, event_log, &pacer_) {}
+      send_side_cc_(clock, nullptr /* observer */, event_log, &pacer_, use_nada) {}
 
 PacketRouter* RtpTransportControllerSend::packet_router() {
   return &packet_router_;

--- a/media/webrtc/trunk/webrtc/call/rtp_transport_controller_send.h
+++ b/media/webrtc/trunk/webrtc/call/rtp_transport_controller_send.h
@@ -26,7 +26,7 @@ class RtcEventLog;
 // per transport, sharing the same congestion controller.
 class RtpTransportControllerSend : public RtpTransportControllerSendInterface {
  public:
-  RtpTransportControllerSend(Clock* clock, webrtc::RtcEventLog* event_log);
+  RtpTransportControllerSend(Clock* clock, webrtc::RtcEventLog* event_log, bool use_nada);
 
   // Implements RtpTransportControllerSendInterface
   PacketRouter* packet_router() override;

--- a/media/webrtc/trunk/webrtc/modules/congestion_controller/congestion_controller_gn/moz.build
+++ b/media/webrtc/trunk/webrtc/modules/congestion_controller/congestion_controller_gn/moz.build
@@ -35,6 +35,7 @@ UNIFIED_SOURCES += [
     "/media/webrtc/trunk/webrtc/modules/congestion_controller/acknowledged_bitrate_estimator.cc",
     "/media/webrtc/trunk/webrtc/modules/congestion_controller/bitrate_estimator.cc",
     "/media/webrtc/trunk/webrtc/modules/congestion_controller/delay_based_bwe.cc",
+    "/media/webrtc/trunk/webrtc/modules/congestion_controller/delay_based_bwe_interface.cc",
     "/media/webrtc/trunk/webrtc/modules/congestion_controller/median_slope_estimator.cc",
     "/media/webrtc/trunk/webrtc/modules/congestion_controller/nada_owd_bwe.cc",
     "/media/webrtc/trunk/webrtc/modules/congestion_controller/probe_bitrate_estimator.cc",

--- a/media/webrtc/trunk/webrtc/modules/congestion_controller/delay_based_bwe.cc
+++ b/media/webrtc/trunk/webrtc/modules/congestion_controller/delay_based_bwe.cc
@@ -70,22 +70,9 @@ size_t ReadTrendlineFilterWindowSize() {
 
 namespace webrtc {
 
-DelayBasedBwe::Result::Result()
-    : updated(false),
-      probe(false),
-      target_bitrate_bps(0),
-      recovered_from_overuse(false) {}
-
-DelayBasedBwe::Result::Result(bool probe, uint32_t target_bitrate_bps)
-    : updated(true),
-      probe(probe),
-      target_bitrate_bps(target_bitrate_bps),
-      recovered_from_overuse(false) {}
-
-DelayBasedBwe::Result::~Result() {}
-
 DelayBasedBwe::DelayBasedBwe(RtcEventLog* event_log, const Clock* clock)
-    : event_log_(event_log),
+    : DelayBasedBweInterface(),
+      event_log_(event_log),
       clock_(clock),
       inter_arrival_(),
       trendline_estimator_(),

--- a/media/webrtc/trunk/webrtc/modules/congestion_controller/delay_based_bwe.h
+++ b/media/webrtc/trunk/webrtc/modules/congestion_controller/delay_based_bwe.h
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include "modules/congestion_controller/delay_based_bwe_interface.h"
 #include "modules/congestion_controller/median_slope_estimator.h"
 #include "modules/congestion_controller/probe_bitrate_estimator.h"
 #include "modules/congestion_controller/trendline_estimator.h"
@@ -31,32 +32,22 @@ namespace webrtc {
 
 class RtcEventLog;
 
-class DelayBasedBwe {
+class DelayBasedBwe: public DelayBasedBweInterface {
  public:
   static const int64_t kStreamTimeOutMs = 2000;
-
-  struct Result {
-    Result();
-    Result(bool probe, uint32_t target_bitrate_bps);
-    ~Result();
-    bool updated;
-    bool probe;
-    uint32_t target_bitrate_bps;
-    bool recovered_from_overuse;
-  };
 
   DelayBasedBwe(RtcEventLog* event_log, const Clock* clock);
   virtual ~DelayBasedBwe();
 
-  Result IncomingPacketFeedbackVector(
+  virtual DelayBasedBweInterface::Result IncomingPacketFeedbackVector(
       const std::vector<PacketFeedback>& packet_feedback_vector,
-      rtc::Optional<uint32_t> acked_bitrate_bps);
-  void OnRttUpdate(int64_t avg_rtt_ms, int64_t max_rtt_ms);
-  bool LatestEstimate(std::vector<uint32_t>* ssrcs,
-                      uint32_t* bitrate_bps) const;
-  void SetStartBitrate(int start_bitrate_bps);
-  void SetMinBitrate(int min_bitrate_bps);
-  int64_t GetExpectedBwePeriodMs() const;
+      rtc::Optional<uint32_t> acked_bitrate_bps) override;
+  virtual void OnRttUpdate(int64_t avg_rtt_ms, int64_t max_rtt_ms) override;
+  virtual bool LatestEstimate(std::vector<uint32_t>* ssrcs,
+                      uint32_t* bitrate_bps) const override;
+  virtual void SetStartBitrate(int start_bitrate_bps) override;
+  virtual void SetMinBitrate(int min_bitrate_bps) override;
+  virtual int64_t GetExpectedBwePeriodMs() const override;
 
  private:
   void IncomingPacketFeedback(const PacketFeedback& packet_feedback);

--- a/media/webrtc/trunk/webrtc/modules/congestion_controller/delay_based_bwe_interface.cc
+++ b/media/webrtc/trunk/webrtc/modules/congestion_controller/delay_based_bwe_interface.cc
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2019 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "modules/congestion_controller/delay_based_bwe_interface.h"
+
+namespace webrtc {
+
+DelayBasedBweInterface::Result::Result()
+    : updated(false),
+      probe(false),
+      target_bitrate_bps(0),
+      recovered_from_overuse(false) {}
+
+DelayBasedBweInterface::Result::Result(bool probe, uint32_t target_bitrate_bps)
+    : updated(true),
+      probe(probe),
+      target_bitrate_bps(target_bitrate_bps),
+      recovered_from_overuse(false) {}
+
+DelayBasedBweInterface::Result::~Result() {}
+
+DelayBasedBweInterface::DelayBasedBweInterface() {}
+
+DelayBasedBweInterface::~DelayBasedBweInterface() {}
+
+}  // namespace webrtc

--- a/media/webrtc/trunk/webrtc/modules/congestion_controller/delay_based_bwe_interface.h
+++ b/media/webrtc/trunk/webrtc/modules/congestion_controller/delay_based_bwe_interface.h
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2019 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef MODULES_CONGESTION_CONTROLLER_DELAY_BASED_BWE_INTERFACE_H_
+#define MODULES_CONGESTION_CONTROLLER_DELAY_BASED_BWE_INTERFACE_H_
+
+#include <vector>
+
+#include "modules/rtp_rtcp/include/rtp_rtcp_defines.h"
+#include "rtc_base/constructormagic.h"
+
+namespace webrtc {
+
+class RtcEventLog;
+
+class DelayBasedBweInterface {
+ public:
+  struct Result {
+    Result();
+    Result(bool probe, uint32_t target_bitrate_bps);
+    ~Result();
+    bool updated;
+    bool probe;
+    uint32_t target_bitrate_bps;
+    bool recovered_from_overuse;
+  };
+
+  DelayBasedBweInterface();
+  virtual ~DelayBasedBweInterface();
+
+  virtual Result IncomingPacketFeedbackVector(
+      const std::vector<PacketFeedback>& packet_feedback_vector,
+      rtc::Optional<uint32_t> acked_bitrate_bps) = 0;
+  virtual void OnRttUpdate(int64_t avg_rtt_ms, int64_t max_rtt_ms) = 0;
+  virtual bool LatestEstimate(std::vector<uint32_t>* ssrcs,
+                      uint32_t* bitrate_bps) const = 0;
+  virtual void SetStartBitrate(int start_bitrate_bps) = 0;
+  virtual void SetMinBitrate(int min_bitrate_bps) = 0;
+  virtual int64_t GetExpectedBwePeriodMs() const = 0;
+
+  RTC_DISALLOW_COPY_AND_ASSIGN(DelayBasedBweInterface);
+};
+
+}  // namespace webrtc
+
+#endif  // MODULES_CONGESTION_CONTROLLER_DELAY_BASED_BWE_INTERFACE_H_

--- a/media/webrtc/trunk/webrtc/modules/congestion_controller/include/send_side_congestion_controller.h
+++ b/media/webrtc/trunk/webrtc/modules/congestion_controller/include/send_side_congestion_controller.h
@@ -15,7 +15,7 @@
 #include <vector>
 
 #include "common_types.h"  // NOLINT(build/include)
-#include "modules/congestion_controller/delay_based_bwe.h"
+#include "modules/congestion_controller/delay_based_bwe_interface.h"
 #include "modules/congestion_controller/nada_owd_bwe.h"
 #include "modules/congestion_controller/transport_feedback_adapter.h"
 #include "modules/include/module.h"
@@ -25,8 +25,6 @@
 #include "rtc_base/criticalsection.h"
 #include "rtc_base/networkroute.h"
 #include "rtc_base/race_checker.h"
-
-#define ENABLE_NADA_OWD 1
 
 namespace rtc {
 struct SentPacket;
@@ -63,7 +61,8 @@ class SendSideCongestionController : public CallStatsObserver,
   SendSideCongestionController(const Clock* clock,
                                Observer* observer,
                                RtcEventLog* event_log,
-                               PacedSender* pacer);
+                               PacedSender* pacer,
+                               bool use_nada);
   ~SendSideCongestionController() override;
 
   void RegisterPacketFeedbackObserver(PacketFeedbackObserver* observer);
@@ -151,12 +150,9 @@ class SendSideCongestionController : public CallStatsObserver,
   bool pacer_paused_;
   rtc::CriticalSection bwe_lock_;
   int min_bitrate_bps_ RTC_GUARDED_BY(bwe_lock_);
+  bool use_nada_ RTC_GUARDED_BY(bwe_lock_);
 
-#ifdef ENABLE_NADA_OWD
-  std::unique_ptr<NadaOwdBwe> delay_based_bwe_ RTC_GUARDED_BY(bwe_lock_);
-#else
-  std::unique_ptr<DelayBasedBwe> delay_based_bwe_ RTC_GUARDED_BY(bwe_lock_);
-#endif
+  std::unique_ptr<DelayBasedBweInterface> delay_based_bwe_ RTC_GUARDED_BY(bwe_lock_);
 
   bool in_cwnd_experiment_;
   int64_t accepted_queue_ms_;

--- a/media/webrtc/trunk/webrtc/modules/congestion_controller/nada_owd_bwe.cc
+++ b/media/webrtc/trunk/webrtc/modules/congestion_controller/nada_owd_bwe.cc
@@ -18,7 +18,6 @@
 #include "rtc_base/constructormagic.h"
 #include "rtc_base/logging.h"
 #include "rtc_base/thread_annotations.h"
-//#include "webrtc/modules/congestion_controller/include/congestion_controller.h"
 
 #include "system_wrappers/include/field_trial.h"
 #include "system_wrappers/include/metrics.h"
@@ -167,23 +166,13 @@ uint32_t NadaOwdBwe::BitrateEstimator::bitrate_bps() const {
 ///  start of NadaOwdBwe (NADA One-way-delay BW Estimation) ///
 
 NadaOwdBwe::NadaOwdBwe(const Clock* clock)
-    : clock_(clock),
-// in_trendline_experiment_(TrendlineFilterExperimentIsEnabled()),
-//      in_median_slope_experiment_(MedianSlopeFilterExperimentIsEnabled()),
-//      inter_arrival_(),
-//      kalman_estimator_(),
-//      trendline_estimator_(),
-//      detector_(),
+    : DelayBasedBweInterface(),
+      clock_(clock),
       receiver_incoming_bitrate_(),
       last_update_ms_(-1),
       first_update_ms_(-1),
       last_seen_packet_ms_(-1),
       last_seen_seqno_(-1),
-//      uma_recorded_(false),
-//      probe_bitrate_estimator_(event_log),
-//      trendline_window_size_(kDefaultTrendlineWindowSize),
-//      trendline_smoothing_coeff_(kDefaultTrendlineSmoothingCoeff),
-//      trendline_threshold_gain_(kDefaultTrendlineThresholdGain),
       nada_rate_in_bps_(kNadaBweDefaultBitrate),
       nada_rmin_in_bps_(kNadaBweDefaultMinBitrate),
       nada_rmax_in_bps_(kNadaBweDefaultMaxBitrate),

--- a/media/webrtc/trunk/webrtc/modules/congestion_controller/nada_owd_bwe.h
+++ b/media/webrtc/trunk/webrtc/modules/congestion_controller/nada_owd_bwe.h
@@ -16,7 +16,7 @@
 #include <utility>
 #include <vector>
 
-#include "modules/congestion_controller/delay_based_bwe.h"  // for Result struct
+#include "modules/congestion_controller/delay_based_bwe_interface.h"
 #include "rtc_base/checks.h"
 #include "rtc_base/constructormagic.h"
 #include "rtc_base/rate_statistics.h"
@@ -26,37 +26,25 @@ namespace webrtc {
 
 class RtcEventLog;
 
-class NadaOwdBwe {
+class NadaOwdBwe: public DelayBasedBweInterface {
  public:
-  // static const int64_t kStreamTimeOutMs = 2000;
-  /*
-  struct Result {
-    Result() : updated(false), probe(false), target_bitrate_bps(0) {}
-    Result(bool probe, uint32_t target_bitrate_bps)
-        : updated(true), probe(probe), target_bitrate_bps(target_bitrate_bps) {}
-    bool updated;
-    bool probe;
-    uint32_t target_bitrate_bps;
-  };
-
-  */
 
   explicit NadaOwdBwe(const Clock* clock);
   virtual ~NadaOwdBwe();
 
   // Triggers BW estimation upon receving a new packet FB vector
-  DelayBasedBwe::Result IncomingPacketFeedbackVector(
+  virtual DelayBasedBweInterface::Result IncomingPacketFeedbackVector(
       const std::vector<PacketFeedback>& packet_feedback_vector,
-      rtc::Optional<uint32_t> acked_bitrate_bps);
+      rtc::Optional<uint32_t> acked_bitrate_bps) override;
 
   // Update local variables fed by others:  RTT, R_min
-  void OnRttUpdate(int64_t avg_rtt_ms, int64_t max_rtt_ms);
+  virtual void OnRttUpdate(int64_t avg_rtt_ms, int64_t max_rtt_ms) override;
   // Answer queries:
-  bool LatestEstimate(std::vector<uint32_t>* ssrcs,
-                      uint32_t* bitrate_bps) const;
-  void SetStartBitrate(int start_bitrate_bps);
-  void SetMinBitrate(int min_bitrate_bps);
-  int64_t GetExpectedBwePeriodMs() const;
+  virtual bool LatestEstimate(std::vector<uint32_t>* ssrcs,
+                      uint32_t* bitrate_bps) const override;
+  virtual void SetStartBitrate(int start_bitrate_bps) override;
+  virtual void SetMinBitrate(int min_bitrate_bps) override;
+  virtual int64_t GetExpectedBwePeriodMs() const override;
 
  private:
 

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -410,6 +410,7 @@ pref("media.navigator.video.enabled", true);
 pref("media.navigator.video.default_fps",30);
 pref("media.navigator.video.use_remb", false);
 pref("media.navigator.video.use_trans_cc", true);
+pref("media.navigator.video.use_nada", true);
 pref("media.navigator.video.use_tmmbr", false);
 pref("media.navigator.audio.use_fec", true);
 pref("media.navigator.video.red_ulpfec_enabled", false);


### PR DESCRIPTION
Now we can have two sessions with different algorithms without rebuilding the repo