### PR TITLE
NADA configuration flag also activates NADA RTT-based congestion control

### DIFF
--- a/media/webrtc/trunk/webrtc/modules/bitrate_controller/bitrate_controller_gn/moz.build
+++ b/media/webrtc/trunk/webrtc/modules/bitrate_controller/bitrate_controller_gn/moz.build
@@ -30,7 +30,8 @@ LOCAL_INCLUDES += [
 UNIFIED_SOURCES += [
     "/media/webrtc/trunk/webrtc/modules/bitrate_controller/bitrate_controller_impl.cc",
     "/media/webrtc/trunk/webrtc/modules/bitrate_controller/nada_bandwidth_estimation.cc",
-    "/media/webrtc/trunk/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.cc"
+    "/media/webrtc/trunk/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.cc",
+    "/media/webrtc/trunk/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation_int.cc"
 ]
 
 if not CONFIG["MOZ_DEBUG"]:

--- a/media/webrtc/trunk/webrtc/modules/bitrate_controller/bitrate_controller_impl.h
+++ b/media/webrtc/trunk/webrtc/modules/bitrate_controller/bitrate_controller_impl.h
@@ -27,8 +27,6 @@
 #include "rtc_base/constructormagic.h"
 #include "rtc_base/criticalsection.h"
 
-#define ENABLE_NADA 1
-
 namespace webrtc {
 
 class BitrateControllerImpl : public BitrateController {

--- a/media/webrtc/trunk/webrtc/modules/bitrate_controller/bitrate_controller_impl.h
+++ b/media/webrtc/trunk/webrtc/modules/bitrate_controller/bitrate_controller_impl.h
@@ -37,7 +37,8 @@ class BitrateControllerImpl : public BitrateController {
   // |observer| is left for project that is not yet updated.
   BitrateControllerImpl(const Clock* clock,
                         BitrateObserver* observer,
-                        RtcEventLog* event_log);
+                        RtcEventLog* event_log,
+                        bool use_nada);
   virtual ~BitrateControllerImpl() {}
 
   bool AvailableBandwidth(uint32_t* bandwidth) const override;
@@ -98,12 +99,8 @@ class BitrateControllerImpl : public BitrateController {
   std::map<uint32_t, uint32_t> ssrc_to_last_received_extended_high_seq_num_
       RTC_GUARDED_BY(critsect_);
 
-#ifdef ENABLE_NADA
-  NADABandwidthEstimation bandwidth_estimation_ RTC_GUARDED_BY(critsect_);
-#else
-  SendSideBandwidthEstimation bandwidth_estimation_ RTC_GUARDED_BY(critsect_);
-#endif
-
+  bool use_nada_;
+  std::unique_ptr<SendSideBandwidthEstimationInt> bandwidth_estimation_ RTC_GUARDED_BY(critsect_);
   uint32_t reserved_bitrate_bps_ RTC_GUARDED_BY(critsect_);
 
   uint32_t last_bitrate_bps_ RTC_GUARDED_BY(critsect_);

--- a/media/webrtc/trunk/webrtc/modules/bitrate_controller/bitrate_controller_unittest.cc
+++ b/media/webrtc/trunk/webrtc/modules/bitrate_controller/bitrate_controller_unittest.cc
@@ -68,7 +68,7 @@ class BitrateControllerTest : public ::testing::Test {
 
   virtual void SetUp() {
     controller_.reset(BitrateController::CreateBitrateController(
-        &clock_, &bitrate_observer_, &event_log_));
+        &clock_, &bitrate_observer_, &event_log_, false));
     controller_->SetStartBitrate(kStartBitrateBps);
     EXPECT_EQ(kStartBitrateBps, bitrate_observer_.last_bitrate_);
     controller_->SetMinMaxBitrate(kMinBitrateBps, kMaxBitrateBps);

--- a/media/webrtc/trunk/webrtc/modules/bitrate_controller/include/bitrate_controller.h
+++ b/media/webrtc/trunk/webrtc/modules/bitrate_controller/include/bitrate_controller.h
@@ -62,10 +62,12 @@ class BitrateController : public Module, public RtcpBandwidthObserver {
   // Remove this method once other other projects does not use it.
   static BitrateController* CreateBitrateController(const Clock* clock,
                                                     BitrateObserver* observer,
-                                                    RtcEventLog* event_log);
+                                                    RtcEventLog* event_log,
+                                                    bool use_nada);
 
   static BitrateController* CreateBitrateController(const Clock* clock,
-                                                    RtcEventLog* event_log);
+                                                    RtcEventLog* event_log,
+                                                    bool use_nada);
 
   virtual ~BitrateController() {}
 

--- a/media/webrtc/trunk/webrtc/modules/bitrate_controller/nada_bandwidth_estimation.cc
+++ b/media/webrtc/trunk/webrtc/modules/bitrate_controller/nada_bandwidth_estimation.cc
@@ -44,18 +44,18 @@ const int64_t kNADAParamMinDeltaMs =  20; // Minimum value of delta for rate cal
 const int64_t kNADAParamMaxDeltaMs = 500; // Maximum value of delta for rate calculation [in ms]
 
 const int64_t kNADAParamLogwinMs = 500; // Observation time window for calculating
-					// packet summary statistics [LOGWIN: in ms]
+                                        // packet summary statistics [LOGWIN: in ms]
 const int64_t kNADAParamQepsMs = 10; 	// Threshold for determining queueing delay build-up [QEPS: in ms]
 const int64_t kNADAParamQboundMs = 50;  // Upper bound on self-inflicted queuing delay [QBOUND: in ms]
 const int64_t kNADAParamDfiltMs = 120;  // Bound on filtering delay [DFILT: in ms]
 const float   kNADAParamGammaMax =0.2;  // Upper bound on rate increase ratio for accelerated ramp-up
-					// [GAMMA_MAX: dimensionless]
+                                        // [GAMMA_MAX: dimensionless]
 const int kNADAParamRateBps =  800000;  // Default rate: 800Kbps
 const int kNADAParamRminBps =  250000;  // Min rate: 250Kbps
 const int kNADAParamRmaxBps = 2500000;  // Max rate: 2.5Mbps
 
 const int kNADALimitNumPackets = 20;    // Number of packets before packet loss calculation is
-					// considered as valid (outside the scope of NADA draft)
+                                        // considered as valid (outside the scope of NADA draft)
 
 }  // namespace
 
@@ -64,7 +64,8 @@ const int kNADALimitNumPackets = 20;    // Number of packets before packet loss 
 // TO-TRY: pass in min/max rates from external modules (e.g., about:config)
 //
 NADABandwidthEstimation::NADABandwidthEstimation(RtcEventLog* event_log)
-    : lost_packets_since_last_loss_update_Q8_(0),
+    : SendSideBandwidthEstimationInt(),
+      lost_packets_since_last_loss_update_Q8_(0),
       expected_packets_since_last_loss_update_(0),
       bitrate_(kNADAParamRateBps),
 //      min_bitrate_configured_(congestion_controller::GetMinBitrateBps()),

--- a/media/webrtc/trunk/webrtc/modules/bitrate_controller/nada_bandwidth_estimation.h
+++ b/media/webrtc/trunk/webrtc/modules/bitrate_controller/nada_bandwidth_estimation.h
@@ -26,12 +26,13 @@
 #include <vector>
 
 #include "modules/rtp_rtcp/include/rtp_rtcp_defines.h"
+#include "modules/bitrate_controller/send_side_bandwidth_estimation_int.h"
 
 namespace webrtc {
 
 class RtcEventLog;
 
-class NADABandwidthEstimation {
+class NADABandwidthEstimation: public SendSideBandwidthEstimationInt {
  public:
 
   NADABandwidthEstimation() = delete;
@@ -39,30 +40,30 @@ class NADABandwidthEstimation {
   virtual ~NADABandwidthEstimation();
 
   // Retrieve current estimate
-  void CurrentEstimate(int* bitrate, uint8_t* loss, int64_t* rtt) const;
+  virtual void CurrentEstimate(int* bitrate, uint8_t* loss, int64_t* rtt) const override;
 
   // Call periodically to update estimate.
-  void UpdateEstimate(int64_t now_ms);
+  virtual void UpdateEstimate(int64_t now_ms) override;
 
   // Call when we receive a RTCP message with TMMBR or REMB.
-  void UpdateReceiverEstimate(int64_t now_ms, uint32_t bandwidth);
+  virtual void UpdateReceiverEstimate(int64_t now_ms, uint32_t bandwidth) override;
 
   // Call when a new delay-based estimate is available.
-  void UpdateDelayBasedEstimate(int64_t now_ms, uint32_t bitrate_bps);
+  virtual void UpdateDelayBasedEstimate(int64_t now_ms, uint32_t bitrate_bps) override;
 
   // Call when we receive a RTCP message with a ReceiveBlock.
-  void UpdateReceiverBlock(uint8_t fraction_loss,
-                           int64_t rtt,
-                           int number_of_packets,
-                           int64_t now_ms);
+  virtual void UpdateReceiverBlock(uint8_t fraction_loss,
+                                   int64_t rtt,
+                                   int number_of_packets,
+                                   int64_t now_ms) override;
 
-  void SetBitrates(int send_bitrate,
-                   int min_bitrate,
-                   int max_bitrate);
+  virtual void SetBitrates(int send_bitrate,
+                           int min_bitrate,
+                           int max_bitrate) override;
 
-  void SetSendBitrate(int bitrate);
-  void SetMinMaxBitrate(int min_bitrate, int max_bitrate);
-  int GetMinBitrate() const;
+  virtual void SetSendBitrate(int bitrate) override;
+  virtual void SetMinMaxBitrate(int min_bitrate, int max_bitrate) override;
+  virtual int GetMinBitrate() const override;
 
  private:
 

--- a/media/webrtc/trunk/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.cc
+++ b/media/webrtc/trunk/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.cc
@@ -104,7 +104,8 @@ bool ReadBweLossExperimentParameters(float* low_loss_threshold,
 }  // namespace
 
 SendSideBandwidthEstimation::SendSideBandwidthEstimation(RtcEventLog* event_log)
-    : lost_packets_since_last_loss_update_Q8_(0),
+    : SendSideBandwidthEstimationInt(),
+      lost_packets_since_last_loss_update_Q8_(0),
       expected_packets_since_last_loss_update_(0),
       current_bitrate_bps_(0),
       min_bitrate_configured_(congestion_controller::GetMinBitrateBps()),

--- a/media/webrtc/trunk/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.h
+++ b/media/webrtc/trunk/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.h
@@ -18,40 +18,41 @@
 #include <vector>
 
 #include "modules/rtp_rtcp/include/rtp_rtcp_defines.h"
+#include "modules/bitrate_controller/send_side_bandwidth_estimation_int.h"
 
 namespace webrtc {
 
 class RtcEventLog;
 
-class SendSideBandwidthEstimation {
+class SendSideBandwidthEstimation: public SendSideBandwidthEstimationInt {
  public:
   SendSideBandwidthEstimation() = delete;
   explicit SendSideBandwidthEstimation(RtcEventLog* event_log);
   virtual ~SendSideBandwidthEstimation();
 
-  void CurrentEstimate(int* bitrate, uint8_t* loss, int64_t* rtt) const;
+  virtual void CurrentEstimate(int* bitrate, uint8_t* loss, int64_t* rtt) const override;
 
   // Call periodically to update estimate.
-  void UpdateEstimate(int64_t now_ms);
+  virtual void UpdateEstimate(int64_t now_ms) override;
 
   // Call when we receive a RTCP message with TMMBR or REMB.
-  void UpdateReceiverEstimate(int64_t now_ms, uint32_t bandwidth);
+  virtual void UpdateReceiverEstimate(int64_t now_ms, uint32_t bandwidth) override;
 
   // Call when a new delay-based estimate is available.
-  void UpdateDelayBasedEstimate(int64_t now_ms, uint32_t bitrate_bps);
+  virtual void UpdateDelayBasedEstimate(int64_t now_ms, uint32_t bitrate_bps) override;
 
   // Call when we receive a RTCP message with a ReceiveBlock.
-  void UpdateReceiverBlock(uint8_t fraction_loss,
-                           int64_t rtt,
-                           int number_of_packets,
-                           int64_t now_ms);
+  virtual void UpdateReceiverBlock(uint8_t fraction_loss,
+                                   int64_t rtt,
+                                   int number_of_packets,
+                                   int64_t now_ms) override;
 
-  void SetBitrates(int send_bitrate,
-                   int min_bitrate,
-                   int max_bitrate);
-  void SetSendBitrate(int bitrate);
-  void SetMinMaxBitrate(int min_bitrate, int max_bitrate);
-  int GetMinBitrate() const;
+  virtual void SetBitrates(int send_bitrate,
+                           int min_bitrate,
+                           int max_bitrate) override;
+  virtual void SetSendBitrate(int bitrate) override;
+  virtual void SetMinMaxBitrate(int min_bitrate, int max_bitrate) override;
+  virtual int GetMinBitrate() const override;
 
  private:
   enum UmaState { kNoUpdate, kFirstDone, kDone };

--- a/media/webrtc/trunk/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation_int.cc
+++ b/media/webrtc/trunk/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation_int.cc
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2019 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "modules/bitrate_controller/send_side_bandwidth_estimation_int.h"
+
+namespace webrtc {
+
+SendSideBandwidthEstimationInt::SendSideBandwidthEstimationInt() {}
+
+SendSideBandwidthEstimationInt::~SendSideBandwidthEstimationInt() {}
+
+}  // namespace webrtc

--- a/media/webrtc/trunk/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation_int.h
+++ b/media/webrtc/trunk/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation_int.h
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2019 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ *
+ *  FEC and NACK added bitrate is handled outside class
+ */
+
+#ifndef MODULES_BITRATE_CONTROLLER_SEND_SIDE_BANDWIDTH_ESTIMATION_INT_H_
+#define MODULES_BITRATE_CONTROLLER_SEND_SIDE_BANDWIDTH_ESTIMATION_INT_H_
+
+namespace webrtc {
+
+class RtcEventLog;
+
+class SendSideBandwidthEstimationInt {
+ public:
+  SendSideBandwidthEstimationInt();
+  virtual ~SendSideBandwidthEstimationInt();
+
+  virtual void CurrentEstimate(int* bitrate, uint8_t* loss, int64_t* rtt) const = 0;
+
+  // Call periodically to update estimate.
+  virtual void UpdateEstimate(int64_t now_ms) = 0;
+
+  // Call when we receive a RTCP message with TMMBR or REMB.
+  virtual void UpdateReceiverEstimate(int64_t now_ms, uint32_t bandwidth) = 0;
+
+  // Call when a new delay-based estimate is available.
+  virtual void UpdateDelayBasedEstimate(int64_t now_ms, uint32_t bitrate_bps) = 0;
+
+  // Call when we receive a RTCP message with a ReceiveBlock.
+  virtual void UpdateReceiverBlock(uint8_t fraction_loss,
+                                   int64_t rtt,
+                                   int number_of_packets,
+                                   int64_t now_ms) = 0;
+
+  virtual void SetBitrates(int send_bitrate,
+                           int min_bitrate,
+                           int max_bitrate) = 0;
+  virtual void SetSendBitrate(int bitrate) = 0;
+  virtual void SetMinMaxBitrate(int min_bitrate, int max_bitrate) = 0;
+  virtual int GetMinBitrate() const = 0;
+};
+}  // namespace webrtc
+#endif  // MODULES_BITRATE_CONTROLLER_SEND_SIDE_BANDWIDTH_ESTIMATION_INT_H_

--- a/media/webrtc/trunk/webrtc/modules/congestion_controller/send_side_congestion_controller.cc
+++ b/media/webrtc/trunk/webrtc/modules/congestion_controller/send_side_congestion_controller.cc
@@ -109,7 +109,7 @@ SendSideCongestionController::SendSideCongestionController(
       event_log_(event_log),
       pacer_(pacer),
       bitrate_controller_(
-          BitrateController::CreateBitrateController(clock_, event_log)),
+          BitrateController::CreateBitrateController(clock_, event_log, use_nada)),
       acknowledged_bitrate_estimator_(
           rtc::MakeUnique<AcknowledgedBitrateEstimator>()),
       probe_controller_(new ProbeController(pacer_, clock_)),


### PR DESCRIPTION
Now both RTT-based NADA and OWD NADA are enabled/disabled at the same time by flag "media.navigator.video.use_nada"
(This turned out to be easier than expected)