### PR TITLE
Added class NadaCore to encapsulate core NADA calculations

### DIFF
--- a/media/webrtc/trunk/webrtc/modules/bitrate_controller/nada_bandwidth_estimation.cc
+++ b/media/webrtc/trunk/webrtc/modules/bitrate_controller/nada_bandwidth_estimation.cc
@@ -74,7 +74,8 @@ NADABandwidthEstimation::NADABandwidthEstimation()
       min_round_trip_time_ms_(-1),
       bwe_incoming_(0),
       delay_based_bitrate_bps_(kNADAParamRateBps),
-      first_report_time_ms_(-1) {
+      first_report_time_ms_(-1),
+      core_() {
 
   printf("Initializing the NADA BW Estimation Module\n");
 
@@ -434,6 +435,8 @@ void NADABandwidthEstimation::UpdateEstimate(int64_t now_ms) {
 
     printf("NADA UpdateEstimate triggered by FB: ts = %lld, fbint = %lld ms, rmode = %d, xcurr = %4.2f, rate = %6d Kbps\n",
             now_ms-first_report_time_ms_, feedback_interval_ms_, rmode, nada_x_curr_, bitrate_/1000);
+
+    core_.TestFunction("NADA rtt");
 
     std::ostringstream os;
     os << std::fixed;

--- a/media/webrtc/trunk/webrtc/modules/bitrate_controller/nada_bandwidth_estimation.h
+++ b/media/webrtc/trunk/webrtc/modules/bitrate_controller/nada_bandwidth_estimation.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "modules/rtp_rtcp/include/rtp_rtcp_defines.h"
+#include "modules/remote_bitrate_estimator/include/nada_core.h"
 #include "send_side_bandwidth_estimation_interface.h"
 
 namespace webrtc {
@@ -112,6 +113,8 @@ class NADABandwidthEstimation: public SendSideBandwidthEstimationInterface {
   uint32_t delay_based_bitrate_bps_;    // delay-based bandwidth estimation, not used
 
   int64_t first_report_time_ms_;
+
+  NadaCore core_;  // core calculations for NADA algorithm
 };
 
 }  // namespace webrtc

--- a/media/webrtc/trunk/webrtc/modules/congestion_controller/nada_owd_bwe.cc
+++ b/media/webrtc/trunk/webrtc/modules/congestion_controller/nada_owd_bwe.cc
@@ -96,7 +96,8 @@ NadaOwdBwe::NadaOwdBwe(const Clock* clock)
       nada_d_fwd_(-1.),
       nada_d_base_(-1.),
       nada_d_queue_(-1.),
-      nada_plr_(0.) {
+      nada_plr_(0.),
+      core_() {
 }
 
 NadaOwdBwe::~NadaOwdBwe() {}
@@ -258,6 +259,8 @@ DelayBasedBwe::Result NadaOwdBwe::IncomingPacketFeedbackVector(
   }
 
   last_arrival_time_ms_ = curr_arrival_time_ms;
+
+  core_.TestFunction("NADA owd");
 
   printf("\t pktstats | delta=%6.2f d_fwd=%6.2f, d_base=%6.2f, d_queue=%6.2f ms, rtt=%6.2f, rtt_b=%6.2f, rtt_rel=%6.2f, plr = %6.2f, %6.2f, r_recv = %6.2f, x_curr=%6.2f\n",
          nada_delta_, nada_d_fwd_, nada_d_base_, nada_d_queue_,

--- a/media/webrtc/trunk/webrtc/modules/congestion_controller/nada_owd_bwe.h
+++ b/media/webrtc/trunk/webrtc/modules/congestion_controller/nada_owd_bwe.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "modules/congestion_controller/delay_based_bwe_interface.h"
+#include "modules/remote_bitrate_estimator/include/nada_core.h"
 #include "rtc_base/checks.h"
 #include "rtc_base/constructormagic.h"
 #include "rtc_base/race_checker.h"
@@ -85,6 +86,7 @@ class NadaOwdBwe: public DelayBasedBweInterface {
   float nada_d_base_;   // baseline forward one-way-delay along path: d_base in draft
   float nada_d_queue_;  // queuing delay: d_queue in draft
   float nada_plr_; 	// packet loss ratio:  XXX in draft
+  NadaCore core_;  // core calculations for NADA algorithm
 
   RTC_DISALLOW_IMPLICIT_CONSTRUCTORS(NadaOwdBwe);
 };

--- a/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/BUILD.gn
+++ b/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/BUILD.gn
@@ -29,6 +29,7 @@ rtc_static_library("remote_bitrate_estimator") {
     "remote_estimator_proxy.cc",
     "remote_estimator_proxy.h",
     "send_time_history.cc",
+    "nada_core.cc",
     "test/bwe_test_logging.h",
   ]
 

--- a/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/include/nada_core.h
+++ b/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/include/nada_core.h
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2020 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef MODULES_REMOTE_BITRATE_ESTIMATOR_INCLUDE_NADA_CORE_H_
+#define MODULES_REMOTE_BITRATE_ESTIMATOR_INCLUDE_NADA_CORE_H_
+
+namespace webrtc {
+
+class NadaCore {
+ public:
+    NadaCore();
+    virtual ~NadaCore();
+
+    void TestFunction(const char * from) const;
+};
+
+}  // namespace webrtc
+
+#endif  // MODULES_REMOTE_BITRATE_ESTIMATOR_INCLUDE_NADA_CORE_H_

--- a/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/nada_core.cc
+++ b/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/nada_core.cc
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2020 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "modules/remote_bitrate_estimator/include/nada_core.h"
+
+namespace webrtc {
+
+NadaCore::NadaCore() {}
+
+NadaCore::~NadaCore() {}
+
+void NadaCore::TestFunction (const char * from) const {
+    printf("[%s]: TestFunction__TestFunction__TestFunction__TestFunction__TestFunction__TestFunction\n", from);
+}
+
+}  // namespace webrtc

--- a/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
+++ b/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
@@ -35,6 +35,7 @@ UNIFIED_SOURCES += [
     "/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/aimd_rate_control.cc",
     "/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/bwe_defines.cc",
     "/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/inter_arrival.cc",
+    "/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/nada_core.cc",
     "/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/overuse_detector.cc",
     "/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/overuse_estimator.cc",
     "/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.cc",


### PR DESCRIPTION
Added skeleton of C++ class to contain core NADA calculation in a common place.
Added a test method (to be removed) that is called from both versions of NADA (owd and rtt).
The result builds and runs correctly